### PR TITLE
Add incremental binary cache indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/target
+.proj-finder/
+.serena/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +278,7 @@ dependencies = [
 name = "proj-finder"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "clap",
  "ignore",
  "serde",
@@ -446,10 +467,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+bincode = { version = "2.0", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 ignore = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -495,6 +495,38 @@ Agent がタグ検索を使うなら、
 毎回フルリビルドすると重くなるため、
 差分更新を前提にした方がよい。
 
+現在の実装では、次の二段構えを採る。
+
+1. `git diff` / `git ls-files` を使う fast path
+2. Git 差分が使えない場合の hash fallback
+
+### fast path
+
+Git リポジトリとして扱える場合は、
+まず以下を使って変更候補を絞る。
+
+- `git diff --name-only --relative`
+- `git diff --name-only --relative --cached`
+- `git ls-files --others --exclude-standard`
+
+これにより、
+
+- tracked な変更
+- staged な変更
+- untracked な新規ファイル
+
+を先に拾う。
+
+### hash fallback
+
+以下のケースでは、
+ファイル列挙 + 内容 hash 比較へ落とす。
+
+- Git コマンドが使えない
+- Git 差分の取得に失敗する
+- `.gitignore` が変更されている
+- インデックスキャッシュが存在しない、または壊れている
+
 基本方針:
 
 - 新規ファイルは追加解析
@@ -533,10 +565,13 @@ Agent がタグ検索を使うなら、
 4. 軽量内容要約器
 5. 位置情報と内容要約の両方を使うタグ生成器
 6. Rust / TypeScript / Python / Go に対する部分 AST 解析
+7. Git 差分 fast path + hash fallback による差分更新
+8. ローカル index 保存
 
 まだ行っていないもの:
 
-- 差分更新
+- Agent ごとの profile 切り替え
+- 人間向けの検索整形出力
 
 現在はこれに加えて、
 **タグに対する構造化検索器** を持つ。
@@ -586,6 +621,18 @@ AST ベースで拾うため、
 - `content_summary`
 - `tags`
 
+差分更新を使う場合は、
+リポジトリルート配下の
+`.proj-finder/files.bin`
+と
+`.proj-finder/tags.bin`
+へ要約キャッシュを保存する。
+
+`files.bin` にはファイル要約本体を、
+`tags.bin` にはタグ辞書と inverted index を持たせる。
+CLI 出力用 JSON とは分離し、
+内部保存は軽量バイナリ形式で扱う。
+
 ### 使い方
 
 ```bash
@@ -606,6 +653,13 @@ CLI は `clap` ベースで、
 走査対象外のファイルやディレクトリは、
 基本的にそのリポジトリの `.gitignore` に従う。
 
+差分更新を使う場合は、
+次のように `--incremental` を付ける。
+
+```bash
+cargo run -- scan . --incremental
+```
+
 旧来の `cargo run -- .` も、互換のため `scan` として扱う。
 
 ### 検索の使い方
@@ -614,6 +668,13 @@ CLI は `clap` ベースで、
 
 ```bash
 cargo run -- search . --query '{"must":["role:docs"],"prefer":["ext:md"],"limit":5}'
+```
+
+差分更新済み index を使いながら検索したい場合は、
+次のように `--incremental` を付ける。
+
+```bash
+cargo run -- search . --incremental --query '{"must":["role:docs"],"prefer":["ext:md"],"limit":5}'
 ```
 
 クエリの形式:

--- a/TODO.md
+++ b/TODO.md
@@ -16,11 +16,11 @@ Agentic Coding Tool から見た使い勝手と
 - [x] 内容要約 (`content_summary`) を生成する
 - [x] タグ (`tags`) を生成する
 - [x] タグに `source` / `confidence` / `evidence` を持たせる
-- [ ] Git 差分 (`git diff`, `git ls-files`) を使って変更候補を高速に絞る
-- [ ] 差分更新で再解析対象だけを更新する
-- [ ] Git 差分が使えない場合の hash fallback を実装する
-- [ ] インデックスの永続化形式を導入する
-- [ ] フルスキャンと差分更新を切り替える仕組みを持つ
+- [x] Git 差分 (`git diff`, `git ls-files`) を使って変更候補を高速に絞る
+- [x] 差分更新で再解析対象だけを更新する
+- [x] Git 差分が使えない場合の hash fallback を実装する
+- [x] インデックスの永続化形式を導入する
+- [x] フルスキャンと差分更新を切り替える仕組みを持つ
 
 ## 検索機能
 
@@ -41,8 +41,8 @@ Agentic Coding Tool から見た使い勝手と
 - [x] 旧来の `cargo run -- .` を互換動作として残す
 - [ ] 出力形式の切り替えオプションを追加する
 - [ ] Agent プロファイル切り替え (`--profile ...`) を追加する
-- [ ] 差分更新用サブコマンドまたはフラグを追加する
-- [ ] Git 差分ベース更新とフルスキャンを選べるようにする
+- [x] 差分更新用サブコマンドまたはフラグを追加する
+- [x] Git 差分ベース更新とフルスキャンを選べるようにする
 
 ## Agent 最適化
 
@@ -77,8 +77,8 @@ Agentic Coding Tool から見た使い勝手と
 - [x] README に CLI の使い方を記載する
 - [x] README に CI / Release の流れを記載する
 - [ ] README に Agent プロファイル設計を追記する
-- [ ] README に差分更新の仕様を追記する
-- [ ] README に Git 差分 fast path と hash fallback の役割分担を追記する
+- [x] README に差分更新の仕様を追記する
+- [x] README に Git 差分 fast path と hash fallback の役割分担を追記する
 
 ## 運用メモ
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
 use model::SearchQuery;
+use scanner::ScanMode;
 
 #[derive(Debug, Parser)]
 #[command(name = "proj-finder")]
@@ -30,12 +31,16 @@ enum Command {
     Scan {
         #[arg(value_name = "ROOT")]
         root: Option<PathBuf>,
+        #[arg(long)]
+        incremental: bool,
     },
     Search {
         #[arg(value_name = "ROOT")]
         root: Option<PathBuf>,
         #[arg(long, value_name = "JSON")]
         query: String,
+        #[arg(long)]
+        incremental: bool,
     },
 }
 
@@ -43,26 +48,42 @@ fn main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Command::Scan { root }) => run_scan(root)?,
-        Some(Command::Search { root, query }) => run_search(root, &query)?,
-        None => run_scan(cli.root)?,
+        Some(Command::Scan { root, incremental }) => run_scan(root, incremental)?,
+        Some(Command::Search {
+            root,
+            query,
+            incremental,
+        }) => run_search(root, &query, incremental)?,
+        None => run_scan(cli.root, false)?,
     }
 
     println!();
     Ok(())
 }
 
-fn run_scan(root: Option<PathBuf>) -> Result<(), Box<dyn Error>> {
+fn run_scan(root: Option<PathBuf>, incremental: bool) -> Result<(), Box<dyn Error>> {
     let root = resolve_repo_root(root)?;
-    let scan_result = scanner::scan_project(&root)?;
+    let scan_result = if incremental {
+        scanner::scan_project_with_mode(&root, ScanMode::Incremental)?
+    } else {
+        scanner::scan_project(&root)?
+    };
     serde_json::to_writer_pretty(std::io::stdout(), &scan_result)?;
     Ok(())
 }
 
-fn run_search(root: Option<PathBuf>, query_json: &str) -> Result<(), Box<dyn Error>> {
+fn run_search(
+    root: Option<PathBuf>,
+    query_json: &str,
+    incremental: bool,
+) -> Result<(), Box<dyn Error>> {
     let root = resolve_repo_root(root)?;
     let query = serde_json::from_str::<SearchQuery>(query_json)?;
-    let scan_result = scanner::scan_project(&root)?;
+    let scan_result = if incremental {
+        scanner::scan_project_with_mode(&root, ScanMode::Incremental)?
+    } else {
+        scanner::scan_project(&root)?
+    };
     let search_result = search::search_files(&scan_result.root, &scan_result.files, query);
 
     serde_json::to_writer_pretty(std::io::stdout(), &search_result)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,11 +63,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 fn run_scan(root: Option<PathBuf>, incremental: bool) -> Result<(), Box<dyn Error>> {
     let root = resolve_repo_root(root)?;
-    let scan_result = if incremental {
-        scanner::scan_project_with_mode(&root, ScanMode::Incremental)?
+    let mode = if incremental {
+        ScanMode::Incremental
     } else {
-        scanner::scan_project(&root)?
+        ScanMode::Full
     };
+    let scan_result = scanner::scan_project_with_mode(&root, mode)?;
     serde_json::to_writer_pretty(std::io::stdout(), &scan_result)?;
     Ok(())
 }
@@ -79,11 +80,12 @@ fn run_search(
 ) -> Result<(), Box<dyn Error>> {
     let root = resolve_repo_root(root)?;
     let query = serde_json::from_str::<SearchQuery>(query_json)?;
-    let scan_result = if incremental {
-        scanner::scan_project_with_mode(&root, ScanMode::Incremental)?
+    let mode = if incremental {
+        ScanMode::Incremental
     } else {
-        scanner::scan_project(&root)?
+        ScanMode::Full
     };
+    let scan_result = scanner::scan_project_with_mode(&root, mode)?;
     let search_result = search::search_files(&scan_result.root, &scan_result.files, query);
 
     serde_json::to_writer_pretty(std::io::stdout(), &search_result)?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,7 +6,7 @@ pub struct ScanResult {
     pub files: Vec<FileSummary>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FileSummary {
     pub file_id: String,
     pub path: String,
@@ -17,7 +17,7 @@ pub struct FileSummary {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LocationSummary {
     pub depth: usize,
     pub dirs: Vec<String>,
@@ -28,7 +28,7 @@ pub struct LocationSummary {
     pub path_patterns: Vec<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Tag {
     pub value: String,
     pub source: String,
@@ -36,7 +36,7 @@ pub struct Tag {
     pub evidence: Vec<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ContentSummary {
     pub imports: Vec<String>,
     pub exports: Vec<String>,
@@ -48,7 +48,7 @@ pub struct ContentSummary {
     pub metrics: ContentMetrics,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ContentMetrics {
     pub byte_count: usize,
     pub line_count: usize,

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -223,12 +223,16 @@ fn load_index(root: &Path) -> io::Result<Option<PersistedIndex>> {
         return Ok(None);
     };
 
-    if files_index.version != INDEX_VERSION
-        || tags_index.version != INDEX_VERSION
-        || files_index.root != root.display().to_string()
-        || tags_index.root != root.display().to_string()
-        || files_index.files.len() != tags_index.file_tags.len()
-    {
+    if files_index.version != INDEX_VERSION || tags_index.version != INDEX_VERSION {
+        return Ok(None);
+    }
+
+    let root_string = root.display().to_string();
+    if files_index.root != root_string || tags_index.root != root_string {
+        return Ok(None);
+    }
+
+    if files_index.files.len() != tags_index.file_tags.len() {
         return Ok(None);
     }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io;
@@ -86,10 +87,6 @@ struct StringTableBuilder {
     ids: HashMap<String, u32>,
 }
 
-pub fn scan_project(root: &Path) -> io::Result<ScanResult> {
-    scan_project_with_mode(root, ScanMode::Full)
-}
-
 pub fn scan_project_with_mode(root: &Path, mode: ScanMode) -> io::Result<ScanResult> {
     let root = root.canonicalize()?;
     match mode {
@@ -144,12 +141,7 @@ fn incremental_scan(root: &Path) -> io::Result<ScanResult> {
         .collect::<HashMap<_, _>>();
 
     let changed_paths = match collect_git_changed_paths(root) {
-        Ok(changed)
-            if !changed.contains(".gitignore")
-                && !changed.iter().any(|path| path.starts_with(".gitignore/")) =>
-        {
-            changed
-        }
+        Ok(changed) if !contains_gitignore_change(&changed) => changed,
         _ => collect_changed_paths_by_hash(&current_map, &cached_map)?,
     };
 
@@ -311,10 +303,16 @@ fn load_files_index(root: &Path) -> io::Result<Option<PersistedFilesIndex>> {
         return Ok(None);
     }
 
-    let bytes = fs::read(path)?;
+    let bytes = fs::read(&path)?;
     match decode_from_slice::<PersistedFilesIndex, _>(&bytes, standard()) {
         Ok((index, _)) => Ok(Some(index)),
-        Err(_) => Ok(None),
+        Err(error) => {
+            eprintln!(
+                "warn: failed to decode files index at {}, falling back to full scan: {error}",
+                path.display()
+            );
+            Ok(None)
+        }
     }
 }
 
@@ -324,10 +322,16 @@ fn load_tags_index(root: &Path) -> io::Result<Option<PersistedTagsIndex>> {
         return Ok(None);
     }
 
-    let bytes = fs::read(path)?;
+    let bytes = fs::read(&path)?;
     match decode_from_slice::<PersistedTagsIndex, _>(&bytes, standard()) {
         Ok((index, _)) => Ok(Some(index)),
-        Err(_) => Ok(None),
+        Err(error) => {
+            eprintln!(
+                "warn: failed to decode tags index at {}, falling back to full scan: {error}",
+                path.display()
+            );
+            Ok(None)
+        }
     }
 }
 
@@ -406,14 +410,15 @@ fn tags_index_path(root: &Path) -> PathBuf {
 
 impl StringTableBuilder {
     fn intern(&mut self, value: &str) -> u32 {
-        if let Some(id) = self.ids.get(value) {
-            return *id;
+        match self.ids.entry(value.to_owned()) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let id = self.strings.len() as u32;
+                self.strings.push(entry.key().clone());
+                entry.insert(id);
+                id
+            }
         }
-        let id = self.strings.len() as u32;
-        let owned = value.to_owned();
-        self.strings.push(owned.clone());
-        self.ids.insert(owned, id);
-        id
     }
 }
 
@@ -444,6 +449,12 @@ fn collect_git_changed_paths(root: &Path) -> io::Result<HashSet<String>> {
     }
 
     Ok(changed)
+}
+
+fn contains_gitignore_change(changed_paths: &HashSet<String>) -> bool {
+    changed_paths
+        .iter()
+        .any(|path| path == ".gitignore" || path.ends_with("/.gitignore"))
 }
 
 fn collect_changed_paths_by_hash(
@@ -1545,14 +1556,16 @@ fn normalize_path(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::fs;
     use std::path::Path;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        ScanMode, analyze_content, detect_kind, files_index_path, generate_tags, load_tags_index,
-        scan_project, scan_project_with_mode, summarize_location, tags_index_path,
+        ScanMode, analyze_content, contains_gitignore_change, detect_kind, files_index_path,
+        generate_tags, load_tags_index, scan_project_with_mode, summarize_location,
+        tags_index_path,
     };
 
     fn temp_path(name: &str) -> PathBuf {
@@ -1714,7 +1727,7 @@ fn parse_fixture() -> &'static str {
         fs::write(root.join("ignored-dir").join("nested.txt"), "ignore")
             .expect("should write nested ignored file");
 
-        let result = scan_project(&root).expect("scan should succeed");
+        let result = scan_project_with_mode(&root, ScanMode::Full).expect("scan should succeed");
         let scanned = result
             .files
             .iter()
@@ -1730,6 +1743,17 @@ fn parse_fixture() -> &'static str {
     }
 
     #[test]
+    fn detects_root_and_nested_gitignore_changes() {
+        let root_gitignore = HashSet::from([".gitignore".to_owned()]);
+        let nested_gitignore = HashSet::from(["packages/app/.gitignore".to_owned()]);
+        let unrelated = HashSet::from(["src/main.rs".to_owned()]);
+
+        assert!(contains_gitignore_change(&root_gitignore));
+        assert!(contains_gitignore_change(&nested_gitignore));
+        assert!(!contains_gitignore_change(&unrelated));
+    }
+
+    #[test]
     fn scan_project_excludes_git_directory_contents() {
         let root = temp_path("exclude-dot-git");
         fs::create_dir_all(root.join(".git")).expect("should create fake git dir");
@@ -1739,7 +1763,7 @@ fn parse_fixture() -> &'static str {
         fs::write(root.join("src").join("main.rs"), "fn main() {}\n")
             .expect("should write source file");
 
-        let result = scan_project(&root).expect("scan should succeed");
+        let result = scan_project_with_mode(&root, ScanMode::Full).expect("scan should succeed");
         let scanned = result
             .files
             .iter()

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -2,31 +2,183 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io;
 use std::path::{Component, Path, PathBuf};
+use std::process::Command;
 
+use bincode::config::standard;
+use bincode::serde::{decode_from_slice, encode_to_vec};
 use ignore::WalkBuilder;
+use serde::{Deserialize, Serialize};
 
 use crate::model::{ContentMetrics, ContentSummary, FileSummary, LocationSummary, ScanResult, Tag};
 use crate::polyglot_ast::analyze_other_file;
 use crate::rust_ast::analyze_rust_file;
 
+const INDEX_DIR: &str = ".proj-finder";
+const FILES_INDEX_FILE: &str = "files.bin";
+const TAGS_INDEX_FILE: &str = "tags.bin";
+const LEGACY_COMBINED_INDEX_FILE: &str = "index.bin";
+const LEGACY_JSON_INDEX_FILE: &str = "index.json";
+const INDEX_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ScanMode {
+    Full,
+    Incremental,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct PersistedFilesIndex {
+    version: u32,
+    root: String,
+    files: Vec<PersistedFileSummary>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct CachedFileSummary {
+    path: String,
+    hash: String,
+    summary: FileSummary,
+}
+
+#[derive(Debug)]
+struct PersistedIndex {
+    version: u32,
+    root: String,
+    files: Vec<CachedFileSummary>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct PersistedTagsIndex {
+    version: u32,
+    root: String,
+    strings: Vec<String>,
+    file_tags: Vec<Vec<CompactTag>>,
+    inverted_index: Vec<CompactPosting>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct PersistedFileSummary {
+    path: String,
+    hash: String,
+    language: Option<String>,
+    kind: String,
+    location_summary: LocationSummary,
+    content_summary: Option<ContentSummary>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct CompactTag {
+    value_id: u32,
+    source_id: u32,
+    confidence: f32,
+    evidence_ids: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct CompactPosting {
+    value_id: u32,
+    file_indices: Vec<u32>,
+}
+
+#[derive(Debug, Default)]
+struct StringTableBuilder {
+    strings: Vec<String>,
+    ids: HashMap<String, u32>,
+}
+
 pub fn scan_project(root: &Path) -> io::Result<ScanResult> {
+    scan_project_with_mode(root, ScanMode::Full)
+}
+
+pub fn scan_project_with_mode(root: &Path, mode: ScanMode) -> io::Result<ScanResult> {
     let root = root.canonicalize()?;
-    let mut file_paths = collect_scannable_files(&root)?;
+    match mode {
+        ScanMode::Full => full_scan(&root),
+        ScanMode::Incremental => incremental_scan(&root),
+    }
+}
+
+fn full_scan(root: &Path) -> io::Result<ScanResult> {
+    let mut file_paths = collect_scannable_files(root)?;
     file_paths.sort();
 
-    let files = file_paths
+    let cached_files = file_paths
         .into_iter()
-        .map(|path| {
-            let relative = path
-                .strip_prefix(&root)
-                .expect("scanned file should stay under root");
-            summarize_file(&path, relative)
-        })
-        .collect();
+        .map(|path| cached_summary_for_path(root, &path))
+        .collect::<io::Result<Vec<_>>>()?;
+    persist_index(root, &cached_files)?;
 
     Ok(ScanResult {
         root: root.display().to_string(),
-        files,
+        files: cached_files
+            .into_iter()
+            .map(|cached| cached.summary)
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn incremental_scan(root: &Path) -> io::Result<ScanResult> {
+    let Some(index) = load_index(root)? else {
+        return full_scan(root);
+    };
+    if index.version != INDEX_VERSION || index.root != root.display().to_string() {
+        return full_scan(root);
+    }
+
+    let mut current_paths = collect_scannable_files(root)?;
+    current_paths.sort();
+    let current_map = current_paths
+        .into_iter()
+        .map(|absolute_path| {
+            let relative = absolute_path
+                .strip_prefix(root)
+                .expect("scanned file should stay under root");
+            (normalize_path(relative), absolute_path)
+        })
+        .collect::<HashMap<_, _>>();
+
+    let cached_map = index
+        .files
+        .into_iter()
+        .map(|cached| (cached.path.clone(), cached))
+        .collect::<HashMap<_, _>>();
+
+    let changed_paths = match collect_git_changed_paths(root) {
+        Ok(changed)
+            if !changed.contains(".gitignore")
+                && !changed.iter().any(|path| path.starts_with(".gitignore/")) =>
+        {
+            changed
+        }
+        _ => collect_changed_paths_by_hash(&current_map, &cached_map)?,
+    };
+
+    let mut ordered_paths = current_map.keys().cloned().collect::<Vec<_>>();
+    ordered_paths.sort();
+
+    let mut cached_files = Vec::new();
+    for path in ordered_paths {
+        if !changed_paths.contains(&path)
+            && let Some(cached) = cached_map.get(&path)
+        {
+            cached_files.push(cached.clone());
+            continue;
+        }
+
+        let absolute_path = current_map
+            .get(&path)
+            .expect("ordered path should resolve to a current file");
+        cached_files.push(cached_summary_for_path(root, absolute_path)?);
+    }
+
+    persist_index(root, &cached_files)?;
+
+    Ok(ScanResult {
+        root: root.display().to_string(),
+        files: cached_files
+            .into_iter()
+            .map(|cached| cached.summary)
+            .collect::<Vec<_>>(),
     })
 }
 
@@ -41,7 +193,7 @@ fn collect_scannable_files(root: &Path) -> io::Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     for entry in builder.build() {
         let entry = entry.map_err(io::Error::other)?;
-        if path_contains_component(entry.path(), ".git") {
+        if path_contains_any_component(entry.path(), &[".git", INDEX_DIR]) {
             continue;
         }
         let Some(file_type) = entry.file_type() else {
@@ -54,6 +206,275 @@ fn collect_scannable_files(root: &Path) -> io::Result<Vec<PathBuf>> {
     }
 
     Ok(files)
+}
+
+fn cached_summary_for_path(root: &Path, absolute_path: &Path) -> io::Result<CachedFileSummary> {
+    let relative = absolute_path
+        .strip_prefix(root)
+        .expect("scanned file should stay under root");
+    let path = normalize_path(relative);
+    let summary = summarize_file(absolute_path, relative);
+    let hash = compute_file_hash(absolute_path)?;
+
+    Ok(CachedFileSummary {
+        path,
+        hash,
+        summary,
+    })
+}
+
+fn load_index(root: &Path) -> io::Result<Option<PersistedIndex>> {
+    let Some(files_index) = load_files_index(root)? else {
+        return Ok(None);
+    };
+    let Some(tags_index) = load_tags_index(root)? else {
+        return Ok(None);
+    };
+
+    if files_index.version != INDEX_VERSION
+        || tags_index.version != INDEX_VERSION
+        || files_index.root != root.display().to_string()
+        || tags_index.root != root.display().to_string()
+        || files_index.files.len() != tags_index.file_tags.len()
+    {
+        return Ok(None);
+    }
+
+    let mut files = Vec::with_capacity(files_index.files.len());
+    for (file, tags) in files_index.files.into_iter().zip(tags_index.file_tags) {
+        let Some(decoded_tags) = decode_tags(&tags, &tags_index.strings) else {
+            return Ok(None);
+        };
+        files.push(CachedFileSummary {
+            path: file.path.clone(),
+            hash: file.hash,
+            summary: FileSummary {
+                file_id: file.path.clone(),
+                path: file.path,
+                language: file.language,
+                kind: file.kind,
+                location_summary: file.location_summary,
+                content_summary: file.content_summary,
+                tags: decoded_tags,
+            },
+        });
+    }
+
+    Ok(Some(PersistedIndex {
+        version: INDEX_VERSION,
+        root: root.display().to_string(),
+        files,
+    }))
+}
+
+fn persist_index(root: &Path, files: &[CachedFileSummary]) -> io::Result<()> {
+    let index_dir = root.join(INDEX_DIR);
+    fs::create_dir_all(&index_dir)?;
+
+    let files_payload = PersistedFilesIndex {
+        version: INDEX_VERSION,
+        root: root.display().to_string(),
+        files: files
+            .iter()
+            .map(|file| PersistedFileSummary {
+                path: file.path.clone(),
+                hash: file.hash.clone(),
+                language: file.summary.language.clone(),
+                kind: file.summary.kind.clone(),
+                location_summary: file.summary.location_summary.clone(),
+                content_summary: file.summary.content_summary.clone(),
+            })
+            .collect(),
+    };
+    let tags_payload = build_tags_index(root, files);
+
+    let files_bytes = encode_to_vec(&files_payload, standard())
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let tags_bytes = encode_to_vec(&tags_payload, standard())
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    fs::write(files_index_path(root), files_bytes)?;
+    fs::write(tags_index_path(root), tags_bytes)?;
+
+    for legacy_file in [LEGACY_COMBINED_INDEX_FILE, LEGACY_JSON_INDEX_FILE] {
+        let legacy_path = root.join(INDEX_DIR).join(legacy_file);
+        if legacy_path.exists() {
+            fs::remove_file(legacy_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn load_files_index(root: &Path) -> io::Result<Option<PersistedFilesIndex>> {
+    let path = files_index_path(root);
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let bytes = fs::read(path)?;
+    match decode_from_slice::<PersistedFilesIndex, _>(&bytes, standard()) {
+        Ok((index, _)) => Ok(Some(index)),
+        Err(_) => Ok(None),
+    }
+}
+
+fn load_tags_index(root: &Path) -> io::Result<Option<PersistedTagsIndex>> {
+    let path = tags_index_path(root);
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let bytes = fs::read(path)?;
+    match decode_from_slice::<PersistedTagsIndex, _>(&bytes, standard()) {
+        Ok((index, _)) => Ok(Some(index)),
+        Err(_) => Ok(None),
+    }
+}
+
+fn build_tags_index(root: &Path, files: &[CachedFileSummary]) -> PersistedTagsIndex {
+    let mut strings = StringTableBuilder::default();
+    let mut file_tags = Vec::with_capacity(files.len());
+    let mut postings = HashMap::<u32, Vec<u32>>::new();
+
+    for (file_index, file) in files.iter().enumerate() {
+        let mut compact_tags = Vec::with_capacity(file.summary.tags.len());
+        for tag in &file.summary.tags {
+            let value_id = strings.intern(&tag.value);
+            let source_id = strings.intern(&tag.source);
+            let evidence_ids = tag
+                .evidence
+                .iter()
+                .map(|evidence| strings.intern(evidence))
+                .collect::<Vec<_>>();
+
+            compact_tags.push(CompactTag {
+                value_id,
+                source_id,
+                confidence: tag.confidence,
+                evidence_ids,
+            });
+            postings
+                .entry(value_id)
+                .or_default()
+                .push(file_index as u32);
+        }
+        file_tags.push(compact_tags);
+    }
+
+    let mut inverted_index = postings
+        .into_iter()
+        .map(|(value_id, file_indices)| CompactPosting {
+            value_id,
+            file_indices,
+        })
+        .collect::<Vec<_>>();
+    inverted_index.sort_by_key(|posting| posting.value_id);
+
+    PersistedTagsIndex {
+        version: INDEX_VERSION,
+        root: root.display().to_string(),
+        strings: strings.strings,
+        file_tags,
+        inverted_index,
+    }
+}
+
+fn decode_tags(tags: &[CompactTag], strings: &[String]) -> Option<Vec<Tag>> {
+    tags.iter()
+        .map(|tag| {
+            Some(Tag {
+                value: strings.get(tag.value_id as usize)?.clone(),
+                source: strings.get(tag.source_id as usize)?.clone(),
+                confidence: tag.confidence,
+                evidence: tag
+                    .evidence_ids
+                    .iter()
+                    .map(|id| strings.get(*id as usize).cloned())
+                    .collect::<Option<Vec<_>>>()?,
+            })
+        })
+        .collect()
+}
+
+fn files_index_path(root: &Path) -> PathBuf {
+    root.join(INDEX_DIR).join(FILES_INDEX_FILE)
+}
+
+fn tags_index_path(root: &Path) -> PathBuf {
+    root.join(INDEX_DIR).join(TAGS_INDEX_FILE)
+}
+
+impl StringTableBuilder {
+    fn intern(&mut self, value: &str) -> u32 {
+        if let Some(id) = self.ids.get(value) {
+            return *id;
+        }
+        let id = self.strings.len() as u32;
+        let owned = value.to_owned();
+        self.strings.push(owned.clone());
+        self.ids.insert(owned, id);
+        id
+    }
+}
+
+fn collect_git_changed_paths(root: &Path) -> io::Result<HashSet<String>> {
+    let mut changed = HashSet::new();
+    for args in [
+        &["diff", "--name-only", "--relative"][..],
+        &["diff", "--name-only", "--relative", "--cached"][..],
+        &["ls-files", "--others", "--exclude-standard"][..],
+    ] {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .output()?;
+        if !output.status.success() {
+            return Err(io::Error::other(String::from_utf8_lossy(&output.stderr)));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+        {
+            changed.insert(normalize_path(Path::new(line)));
+        }
+    }
+
+    Ok(changed)
+}
+
+fn collect_changed_paths_by_hash(
+    current_map: &HashMap<String, PathBuf>,
+    cached_map: &HashMap<String, CachedFileSummary>,
+) -> io::Result<HashSet<String>> {
+    let mut changed = HashSet::new();
+
+    for (path, absolute_path) in current_map {
+        let hash = compute_file_hash(absolute_path)?;
+        let cached_hash = cached_map.get(path).map(|cached| cached.hash.as_str());
+        if cached_hash != Some(hash.as_str()) {
+            changed.insert(path.clone());
+        }
+    }
+
+    Ok(changed)
+}
+
+fn compute_file_hash(path: &Path) -> io::Result<String> {
+    let bytes = fs::read(path)?;
+    Ok(fnv1a_hash(&bytes))
+}
+
+fn fnv1a_hash(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
 }
 
 fn summarize_file(absolute_path: &Path, relative_path: &Path) -> FileSummary {
@@ -1129,7 +1550,10 @@ mod tests {
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{analyze_content, detect_kind, generate_tags, scan_project, summarize_location};
+    use super::{
+        ScanMode, analyze_content, detect_kind, files_index_path, generate_tags, load_tags_index,
+        scan_project, scan_project_with_mode, summarize_location, tags_index_path,
+    };
 
     fn temp_path(name: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -1324,6 +1748,131 @@ fn parse_fixture() -> &'static str {
 
         assert!(scanned.contains(&"src/main.rs"));
         assert!(!scanned.contains(&".git/HEAD"));
+
+        fs::remove_dir_all(root).expect("should clean up temp dir");
+    }
+
+    #[test]
+    fn incremental_scan_persists_index_and_updates_changed_files() {
+        let root = temp_path("incremental-update");
+        fs::create_dir_all(root.join(".git")).expect("should create fake git dir");
+        fs::create_dir_all(root.join("src")).expect("should create src dir");
+        fs::write(root.join("src").join("main.rs"), "fn main() {}\n")
+            .expect("should write source file");
+
+        let first = scan_project_with_mode(&root, ScanMode::Incremental)
+            .expect("first incremental scan should succeed");
+        assert!(files_index_path(&root).exists());
+        assert!(tags_index_path(&root).exists());
+        assert!(
+            !first
+                .files
+                .iter()
+                .any(|file| file.path.starts_with(".proj-finder/"))
+        );
+
+        fs::write(
+            root.join("src").join("main.rs"),
+            "use reqwest::Client;\nfn main() {}\n",
+        )
+        .expect("should update source file");
+
+        let second = scan_project_with_mode(&root, ScanMode::Incremental)
+            .expect("second incremental scan should succeed");
+        let main_file = second
+            .files
+            .iter()
+            .find(|file| file.path == "src/main.rs")
+            .expect("main file should exist");
+        let imports = &main_file
+            .content_summary
+            .as_ref()
+            .expect("main file should have content summary")
+            .imports;
+
+        assert!(imports.contains(&"reqwest::client".to_owned()));
+
+        fs::remove_dir_all(root).expect("should clean up temp dir");
+    }
+
+    #[test]
+    fn persisted_tags_index_deduplicates_values_and_builds_postings() {
+        let root = temp_path("tag-index");
+        fs::create_dir_all(root.join(".git")).expect("should create fake git dir");
+        fs::create_dir_all(root.join("src")).expect("should create src dir");
+        fs::write(root.join("src").join("main.rs"), "fn main() {}\n")
+            .expect("should write main file");
+        fs::write(root.join("src").join("lib.rs"), "pub fn run() {}\n")
+            .expect("should write library file");
+
+        scan_project_with_mode(&root, ScanMode::Incremental)
+            .expect("incremental scan should succeed");
+        let tags_index = load_tags_index(&root)
+            .expect("tag index should load")
+            .expect("tag index should exist");
+
+        assert_eq!(
+            tags_index
+                .strings
+                .iter()
+                .filter(|value| value.as_str() == "lang:rust")
+                .count(),
+            1
+        );
+
+        let lang_rust_id = tags_index
+            .strings
+            .iter()
+            .position(|value| value == "lang:rust")
+            .expect("lang:rust should be interned") as u32;
+        let posting = tags_index
+            .inverted_index
+            .iter()
+            .find(|posting| posting.value_id == lang_rust_id)
+            .expect("lang:rust should have a posting list");
+        assert_eq!(posting.file_indices.len(), 2);
+
+        fs::remove_dir_all(root).expect("should clean up temp dir");
+    }
+
+    #[test]
+    fn incremental_scan_removes_deleted_files() {
+        let root = temp_path("incremental-remove");
+        fs::create_dir_all(root.join(".git")).expect("should create fake git dir");
+        fs::create_dir_all(root.join("src")).expect("should create src dir");
+        fs::write(root.join("src").join("main.rs"), "fn main() {}\n")
+            .expect("should write main file");
+        fs::write(root.join("src").join("lib.rs"), "pub fn run() {}\n")
+            .expect("should write library file");
+
+        scan_project_with_mode(&root, ScanMode::Incremental)
+            .expect("first incremental scan should succeed");
+        fs::remove_file(root.join("src").join("lib.rs")).expect("should remove library file");
+
+        let second = scan_project_with_mode(&root, ScanMode::Incremental)
+            .expect("second incremental scan should succeed");
+
+        assert!(second.files.iter().any(|file| file.path == "src/main.rs"));
+        assert!(!second.files.iter().any(|file| file.path == "src/lib.rs"));
+
+        fs::remove_dir_all(root).expect("should clean up temp dir");
+    }
+
+    #[test]
+    fn incremental_scan_falls_back_when_index_is_invalid() {
+        let root = temp_path("incremental-invalid-index");
+        fs::create_dir_all(root.join(".git")).expect("should create fake git dir");
+        fs::create_dir_all(root.join("src")).expect("should create src dir");
+        fs::create_dir_all(root.join(".proj-finder")).expect("should create index dir");
+        fs::write(root.join(".proj-finder").join("files.bin"), "not-bincode")
+            .expect("should write invalid index");
+        fs::write(root.join("src").join("main.rs"), "fn main() {}\n")
+            .expect("should write source file");
+
+        let result = scan_project_with_mode(&root, ScanMode::Incremental)
+            .expect("incremental scan should fall back to full scan");
+
+        assert!(result.files.iter().any(|file| file.path == "src/main.rs"));
 
         fs::remove_dir_all(root).expect("should clean up temp dir");
     }


### PR DESCRIPTION
## Summary
- add incremental scan mode backed by persisted cache files
- switch internal cache storage from a single JSON file to binary files
- split cached file summaries and tag/inverted-index storage with string deduplication

## Testing
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo run --quiet -- scan --incremental
- cargo run --quiet -- search --incremental --query {"must":["lang:rust"],"prefer":["role:entrypoint"],"limit":3}
